### PR TITLE
Automatically disable the Republication Tracker Tool widget on posts in the 'download' content type

### DIFF
--- a/wp-content/themes/wisconsinwatch/functions.php
+++ b/wp-content/themes/wisconsinwatch/functions.php
@@ -22,6 +22,7 @@ require_once( get_template_directory() . '/largo-apis.php' );
 function wcij_includes() {
 	$includes = array(
 		'/inc/custom-post-types.php',
+		'/inc/compat-republication-tracker-tool.php',
 		'/inc/metaboxes.php',
 		'/inc/donation-form.php',
 	);

--- a/wp-content/themes/wisconsinwatch/inc/compat-republication-tracker-tool.php
+++ b/wp-content/themes/wisconsinwatch/inc/compat-republication-tracker-tool.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Compatibility functions for the Republication Tracker Tool plugin
+ *
+ * @link https://github.com/INN/republication-tracker-tool
+ * @link https://wordpress.org/plugins/republication-tracker-tool/
+ */
+
+/**
+* Hide the Republication sharing widget on posts that are
+* included in the downloads post type
+*
+* @return bool Whether or not the sharing widget should be hidden
+* @link https://secure.helpscout.net/conversation/1016863827/4711?folderId=2730118 convo leading to why
+* @since Republication Tracker Tool version 1.0.2
+*/
+function remove_republish_button_from_downloads( $hide_republication_widget, $post ){
+	if( true !== $hide_republication_widget ){
+		// if the current post is in this category, return true
+		if ( 'download' === $post->post_type ) {
+			// returning true will cause the filter to hide the button
+			$hide_republication_widget = true;
+		}
+	}
+	return $hide_republication_widget;
+}
+add_filter( 'hide_republication_widget', 'remove_republish_button_from_downloads', 10, 2 );


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Adds a filter in the style recommended by https://github.com/INN/republication-tracker-tool/blob/master/docs/removing-republish-button-from-categories.md for the

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For https://secure.helpscout.net/conversation/1016863827/4711?folderId=2730118

## Testing/Questions

Features that this PR affects:

- the "downloads" post type and the Republication Tracker Tool widget

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?

Steps to test this PR:

1. Install and activate https://wordpress.org/plugins/republication-tracker-tool/
2. Add a Republication Tracker Tool widget to the Article Bottom widget area
3. Check that the widget appears on "post" posts and on posts in the "downloads" post_type, like `/download-content/asian-restaurants-and-chicago-employment-agencies-accused-of-exploiting-latino-workers-in-midwest/`
4. Check out this branch
5. Check that the widget continues to appear on "post" posts, but not on posts in the "downloads" post type